### PR TITLE
Replace CommentExpressions with CommentExtensions, fix docs mistake

### DIFF
--- a/content/en/docs/4.guides/15.comments.md
+++ b/content/en/docs/4.guides/15.comments.md
@@ -63,12 +63,12 @@ where `[node.id]` refers to the nodes that are covered by this comment
 ## Selectable comments {#selectable}
 
 ```ts
-import { CommentExpressions } from "rete-comment-plugin";
+import { CommentExtensions } from "rete-comment-plugin";
 
 const selector = AreaExtensions.selector();
 const accumulating = AreaExtensions.accumulateOnCtrl();
 
-CommentExpressions.selectable(comment, selector, accumulating);
+CommentExtensions.selectable(comment, selector, accumulating);
 ```
 
 ## Edit comment text {#edit-text}


### PR DESCRIPTION
As reported by "Lyss" in the discord server, fix a minor documentation issue.

The right expression can be seen here: https://github.com/retejs/comment-plugin/blob/main/src/index.ts#L14C13-L14C30 