### PR TITLE
fix(typedoc,transformer): sanitize text

### DIFF
--- a/typedoc/transformer.ts
+++ b/typedoc/transformer.ts
@@ -74,7 +74,7 @@ function getAnchor(data: ProjectReflection, id: number) {
 }
 
 function link(data, arg, text) {
-  return `[${text}](#${getAnchor(data, arg.target)})`;
+  return `[${sanitize(text)}](#${getAnchor(data, arg.target)})`;
 }
 
 function stringifyObject(type: ReflectionType) {
@@ -97,6 +97,15 @@ function getPriority(item: Reflection) {
   return +(tags.find((item) => item.tag === '@priority')?.content[0].text || 0);
 }
 
+function sanitize(text: string) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 async function typedocToMarkdown(
   data: ProjectReflection,
   children: DeclarationReflection[] | undefined = [],
@@ -109,7 +118,7 @@ async function typedocToMarkdown(
     if (parameters && parameters.length) {
       markdown.push('| Parameter | Extends | Description |');
       markdown.push('| ---- | ---- | ----------- |');
-      parameters.forEach(({ name, type, comment }) => markdown.push(`| ${name} | \`${type || 'any'}\` | ${comment} |`));
+      parameters.forEach(({ name, type, comment }) => markdown.push(`| ${name} | \`${sanitize(type) || 'any'}\` | ${comment} |`));
     }
   }
   function throws(ref: Reflection) {


### PR DESCRIPTION
### Description

Sanitize text for generated API markdown
![image](https://github.com/user-attachments/assets/1a1acc71-599f-4aae-ad9e-fe265216e4b7)

### Related Issues

https://discord.com/channels/1081223198055604244/1088598977735299142/1320634867125583875

### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

<!-- Any additional information or notes for the reviewers. -->
