### PR TITLE
feat(docs): update to support angular 22

### DIFF
--- a/content/en/docs/03.concepts/6.integration.md
+++ b/content/en/docs/03.concepts/6.integration.md
@@ -28,7 +28,7 @@ By default, you can use the classic preset that has built-in components for:
 - some controls (numeric or text input fields)
 
 ```ts
-import { AngularPlugin, AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/21'
+import { AngularPlugin, AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/22'
 
 const angular = new AngularPlugin<Schemes, AngularArea2D<Schemes>>({ injector })
 

--- a/content/en/docs/04.guides/02.renderers/3.angular.md
+++ b/content/en/docs/04.guides/02.renderers/3.angular.md
@@ -22,29 +22,29 @@ This guide is an extension of the [Basic](/docs/guides/basic) guide and provides
 
 This plugin offers a classic preset that comes with visual components for nodes, connections, sockets, and input controls.
 
-Compatible with Angular 12, 13, 14, 15, 16, 17, 18, 19, 20 and 21
+Compatible with Angular 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 and 22
 
-This plugin is **exclusively** designed for Angular applications as it requires an `Injector` instance, unlike other render plugins. Additionally, the plugin supports Standalone mode in integration starting from Angular 19, with enhanced features in Angular 20 and 21.
+This plugin is **exclusively** designed for Angular applications as it requires an `Injector` instance, unlike other render plugins. Additionally, the plugin supports Standalone mode in integration starting from Angular 19, with enhanced features in Angular 20, 21 and 22.
 
 ## Install dependencies {#install-dependencies}
 
 :kit
 
 ```bash
-npm i rete-angular-plugin rete-render-utils @angular/elements@21
+npm i rete-angular-plugin rete-render-utils @angular/elements@22
 ```
 
 **Please note**: this plugin relies on `@angular/elements`, which is based on Web Components. However, Web Components have a limitation - they [cannot be unregistered](https://github.com/WICG/webcomponents/issues/754). This limitation may result in the reuse of the initial Angular component instead of creating a new one when a node with the same identifier is added, potentially leading to the use of outdated data within a custom node, such as data from an injected service.
 
 ## Plugin connection {#connect-plugin}
 
-This is an example of integration in **Angular 21**, but you can specify a different version (12, 13, 14, 15, 16, 17, 18, 19, 20 or 21) in the import that matches the version of your application.
+This is an example of integration in **Angular 22**, but you can specify a different version (12, 13, 14, 15, 16, 17, 18, 19, 20, 21 or 22) in the import that matches the version of your application.
 
 These versions have been compiled with Ivy.
 
 ```ts
 import { AreaPlugin } from "rete-area-plugin";
-import { AngularPlugin, Presets, AngularArea2D } from "rete-angular-plugin/21";
+import { AngularPlugin, Presets, AngularArea2D } from "rete-angular-plugin/22";
 
 type AreaExtra = AngularArea2D<Schemes>;
 
@@ -86,7 +86,7 @@ node.addControl('my-control', new ClassicPreset.InputControl("number", {
 If you want to add different types of controls, you can return the necessary component in the `control` handler of `customize` property.
 
 ```tsx
-import { ControlComponent } from "rete-angular-plugin/21";
+import { ControlComponent } from "rete-angular-plugin/22";
 import { MyButtonComponent } from './my-button.component'
 
 render.addPreset(Presets.classic.setup({
@@ -154,7 +154,7 @@ The implementation of `CustomNodeComponent` is available in the **custom-node.co
 You can add an extra condition to apply this component only to specific nodes.
 
 ```ts
-import { NodeComponent } from "rete-angular-plugin/21";
+import { NodeComponent } from "rete-angular-plugin/22";
 
 render.addPreset(Presets.classic.setup({
   customize: {

--- a/content/en/docs/19.quality-assurance.md
+++ b/content/en/docs/19.quality-assurance.md
@@ -2,7 +2,7 @@
 description: Learn about our quality assurance practices, including unit and E2E testing. We rely on Playwright for comprehensive testing from the user's perspective
 keywords: qa,quality assurance,unit testing,e2e testing,playwright
 stacks: [
-  { name: "Angular", versions: [21,20,19,18,17,16,15,14,13,12] },
+  { name: "Angular", versions: [22,21,20,19,18,17,16,15,14,13,12] },
   { name: "Svelte", versions: [5,4,3] },
   { name: "Vue.js", versions: [3,2] },
   { name: "React.js", versions: [19,18,17,16], warnings: [{ browser: 'Chromium,Firefox,WebKit', version: 16, text: 'Known issue with movement' }] },

--- a/content/uk/docs/03.concepts/6.integration.md
+++ b/content/uk/docs/03.concepts/6.integration.md
@@ -28,7 +28,7 @@ keywords: інтеграція,ui,рендерінг,react.js,vue.js,angular,sve
 - деяких елементів керування (поля введення чисел або тексту)
 
 ```ts
-import { AngularPlugin, AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/21'
+import { AngularPlugin, AngularArea2D, Presets as AngularPresets } from 'rete-angular-plugin/22'
 
 const angular = new AngularPlugin<Schemes, AngularArea2D<Schemes>>({ injector })
 

--- a/content/uk/docs/04.guides/02.renderers/3.angular.md
+++ b/content/uk/docs/04.guides/02.renderers/3.angular.md
@@ -22,29 +22,29 @@ keywords: angular,рендерінг
 
 Цей плагін пропонує класичний пресет, який містить візуальні компоненти для вузлів, з’єднань, сокетів і елементів керування введенням.
 
-Сумісний з Angular 12, 13, 14, 15, 16, 17, 18, 19, 20 та 21
+Сумісний з Angular 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 та 22
 
-Цей плагін розроблено **ексклюзивно** для додатків Angular, оскільки для нього потрібен екземпляр `Injector`, на відміну від інших плагінів візуалізації. Окрім цього, плагін підтримує Standalone режим в інтеграції починаючи з Angular 19, з покращеними функціями в Angular 20 та 21.
+Цей плагін розроблено **ексклюзивно** для додатків Angular, оскільки для нього потрібен екземпляр `Injector`, на відміну від інших плагінів візуалізації. Окрім цього, плагін підтримує Standalone режим в інтеграції починаючи з Angular 19, з покращеними функціями в Angular 20, 21 та 22.
 
 ## Встановити залежності {#install-dependencies}
 
 :kit
 
 ```bash
-npm i rete-angular-plugin rete-render-utils @angular/elements@21
+npm i rete-angular-plugin rete-render-utils @angular/elements@22
 ```
 
 **Зверніть увагу**: цей плагін покладається на `@angular/elements`, який базується на Веб компонентах. Однак Веб компоненти мають обмеження — їх [реєстрацію не можна скасувати](https://github.com/WICG/webcomponents/issues/754). Це обмеження може призвести до повторного використання початкового компонента Angular замість створення нового, коли додається вузол із тим самим ідентифікатором, що потенційно може призвести до використання застарілих даних у кастомному вузлі, таких як дані з ін'єктованого сервісу.
 
 ## Підключення планіга {#connect-plugin}
 
-Це приклад інтеграції в **Angular 21**, але ви можете вказати іншу версію (12, 13, 14, 15, 16, 17, 18, 19, 20 або 21) в імпорті, яка відповідає версії вашого додатку.
+Це приклад інтеграції в **Angular 22**, але ви можете вказати іншу версію (12, 13, 14, 15, 16, 17, 18, 19, 20, 21 або 22) в імпорті, яка відповідає версії вашого додатку.
 
 Ці версії були скомпільовані за допомогою Ivy.
 
 ```ts
 import { AreaPlugin } from "rete-area-plugin";
-import { AngularPlugin, Presets, AngularArea2D } from "rete-angular-plugin/21";
+import { AngularPlugin, Presets, AngularArea2D } from "rete-angular-plugin/22";
 
 type AreaExtra = AngularArea2D<Schemes>;
 
@@ -86,7 +86,7 @@ node.addControl('my-control', new ClassicPreset.InputControl("number", {
 Якщо ви хочете додати різні типи контролів, ви можете повернути необхідний функціональний компонент в обробнику `control` властивості `customize`.
 
 ```tsx
-import { ControlComponent } from "rete-angular-plugin/21";
+import { ControlComponent } from "rete-angular-plugin/22";
 import { MyButtonComponent } from './my-button.component'
 
 render.addPreset(Presets.classic.setup({
@@ -154,7 +154,7 @@ render.addPreset(Presets.classic.setup({
 Ви можете додати додаткову умову для застосування цього компонента лише до певних вузлів.
 
 ```ts
-import { NodeComponent } from "rete-angular-plugin/21";
+import { NodeComponent } from "rete-angular-plugin/22";
 
 render.addPreset(Presets.classic.setup({
   customize: {

--- a/content/uk/docs/19.quality-assurance.md
+++ b/content/uk/docs/19.quality-assurance.md
@@ -2,7 +2,7 @@
 description: Дізнайтеся про наші методи забезпечення якості, включаючи юніт тестування та тестування E2E. Ми покладаємося на Playwright для комплексного тестування з точки зору користувача
 keywords: qa,забезпечення якості,юніт тестування,e2e тестування,playwright
 stacks: [
-  { name: "Angular", versions: [21,20,19,18,17,16,15,14,13,12] },
+  { name: "Angular", versions: [22,21,20,19,18,17,16,15,14,13,12] },
   { name: "Svelte", versions: [5,4,3] },
   { name: "Vue.js", versions: [3,2] },
   { name: "React.js", versions: [19,18,17,16], warnings: [{ browser: 'Chromium,Firefox,WebKit', version: 16, text: 'Відома проблема з переміщенням' }] },


### PR DESCRIPTION
### Description

Update documentation to reflect **Angular 22** support in `rete-angular-plugin`, following the same scope as the Angular 21 docs refresh.

**Changes (en + uk):**
- `docs/concepts/integration` — bump example import to `rete-angular-plugin/22`
- `docs/guides/renderers/angular` — update compatibility list, install command (`@angular/elements@22`), primary example version, and all versioned import paths
- `docs/quality-assurance` — add `22` to the Angular versions matrix (`[22,21,20,...]`)

No functional code changes — documentation only.


### Related Issues

https://github.com/retejs/angular-plugin/pull/374
https://github.com/retejs/rete-kit/pull/74
https://github.com/retejs/rete-qa/pull/62

### Checklist

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [x] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).