### PR TITLE
feat(docs): document comments history preset

### DIFF
--- a/content/en/docs/04.guides/14.undo-redo.md
+++ b/content/en/docs/04.guides/14.undo-redo.md
@@ -11,6 +11,7 @@ This guide is based on the [Basic](/docs/guides/basic) guide. It is recommended 
 
 ::references
 :ref-example{title="History" link="/examples/history"}
+:ref-guide{title="Comments" link="/docs/guides/comments"}
 :ref-github{title="Plugin" link="https://github.com/retejs/history-plugin"}
 ::
 
@@ -43,6 +44,33 @@ history.addPreset(Presets.classic.setup())
 ```
 
 It is responsible for tracking the history of adding, removing, or translating nodes, as well as tracking the adding and removing of connections.
+
+## Comments preset {#comments-preset}
+
+To include comments in the undo/redo stack, install `rete-comment-plugin` version **2.2.0** or higher and register the comments preset together with the classic one. Pass the `CommentPlugin` instance into the preset and widen the history action type with `CommentHistoryActions`.
+
+```ts
+import { CommentPlugin } from "rete-comment-plugin";
+import {
+  HistoryPlugin,
+  HistoryActions,
+  CommentHistoryActions,
+  Presets
+} from "rete-history-plugin";
+
+const comment = new CommentPlugin<Schemes, AreaExtra>();
+const history = new HistoryPlugin<Schemes, HistoryActions<Schemes> | CommentHistoryActions>();
+
+area.use(comment);
+area.use(history);
+
+history.addPreset(Presets.classic.setup())
+history.addPreset(Presets.comments.setup({ comment }))
+```
+
+This preset tracks creating, removing, editing, and dragging comments, as well as changes to frame membership (for example, when a node is dragged into or out of a frame).
+
+See the [Comments](/docs/guides/comments) guide for comment setup details. If you enable both **History** and **Comments** features in [Rete Kit](/docs/development/rete-kit) (version **1.21.0** or higher), this wiring is generated automatically.
 
 ## Usage {#usage}
 

--- a/content/en/docs/04.guides/15.comments.md
+++ b/content/en/docs/04.guides/15.comments.md
@@ -11,6 +11,7 @@ This guide is based on the [Basic](/docs/guides/basic) guide. It is recommended 
 
 ::references
 :ref-example{title="Comments" link="/examples/comments"}
+:ref-guide{title="Undo/Redo" link="/docs/guides/undo-redo"}
 :ref-github{title="Plugin" link="https://github.com/retejs/comment-plugin"}
 ::
 
@@ -49,7 +50,7 @@ area.use(comment);
 Adding an inline comment
 
 ```ts
-comment.addInline("Inline comment text", [360, -20], node.dd);
+comment.addInline("Inline comment text", [360, -20], node.id);
 ```
 
 where `[360, -20]` is the position of the comment, which can be placed freely in relation to the `node` it is attached to.
@@ -86,5 +87,9 @@ const comment = new CommentPlugin<Schemes, AreaExtra>({
 ```
 
 where the `edit` property must accept an asynchronous function that returns the text for the comment.
+
+## Undo/Redo {#undo-redo}
+
+Comment changes can be included in the undo/redo stack via `rete-history-plugin` and its comments preset. Setup details are in the [Undo/Redo](/docs/guides/undo-redo#comments-preset) guide.
 
 Check out the complete result on the [Comments](/examples/comments) example page.

--- a/content/uk/docs/04.guides/14.undo-redo.md
+++ b/content/uk/docs/04.guides/14.undo-redo.md
@@ -11,6 +11,7 @@ keywords: скасувати,повторити,історія,rete-history-plug
 
 ::references
 :ref-example{title="Історія змін" link="/uk/examples/history"}
+:ref-guide{title="Коментарі" link="/uk/docs/guides/comments"}
 :ref-github{title="Плагін" link="https://github.com/retejs/history-plugin"}
 ::
 
@@ -43,6 +44,33 @@ history.addPreset(Presets.classic.setup())
 ```
 
 Він відповідає за трекінг історії додавання, видалення або переміщення вузлів, а також за трекунг додавання та видалення з'єднань.
+
+## Пресет коментарів {#comments-preset}
+
+Щоб додати коментарі до стеку скасування/повторення, встановіть `rete-comment-plugin` версії **2.2.0** або новішої та підключіть пресет коментарів разом із класичним. Передайте екземпляр `CommentPlugin` у пресет і розширіть тип дій історії за допомогою `CommentHistoryActions`.
+
+```ts
+import { CommentPlugin } from "rete-comment-plugin";
+import {
+  HistoryPlugin,
+  HistoryActions,
+  CommentHistoryActions,
+  Presets
+} from "rete-history-plugin";
+
+const comment = new CommentPlugin<Schemes, AreaExtra>();
+const history = new HistoryPlugin<Schemes, HistoryActions<Schemes> | CommentHistoryActions>();
+
+area.use(comment);
+area.use(history);
+
+history.addPreset(Presets.classic.setup())
+history.addPreset(Presets.comments.setup({ comment }))
+```
+
+Цей пресет відстежує створення, видалення, редагування та перетягування коментарів, а також зміни членства у фреймі (наприклад, коли вузол перетягують у фрейм або з нього).
+
+Деталі налаштування коментарів — у гайді [Коментарі](/uk/docs/guides/comments). Якщо увімкнути обидві функції **History** і **Comments** у [Rete Kit](/uk/docs/development/rete-kit) (версія **1.21.0** або новіша), це підключення генерується автоматично.
 
 ## Використання {#usage}
 

--- a/content/uk/docs/04.guides/15.comments.md
+++ b/content/uk/docs/04.guides/15.comments.md
@@ -11,6 +11,7 @@ keywords: коментарі,rete-comment-plugin
 
 ::references
 :ref-example{title="Коментарі" link="/uk/examples/comments"}
+:ref-guide{title="Undo/Redo" link="/uk/docs/guides/undo-redo"}
 :ref-github{title="Плагін" link="https://github.com/retejs/comment-plugin"}
 ::
 
@@ -49,7 +50,7 @@ area.use(comment);
 Додавання інлайн коментаря
 
 ```ts
-comment.addInline("Текст інлайн коментаря", [360, -20], node.dd);
+comment.addInline("Текст інлайн коментаря", [360, -20], node.id);
 ```
 
 де `[360, -20]` - це позиція коментаря, який може бути вільно розміщений по відношенню до `node`, до якого він приєднаний.
@@ -86,5 +87,9 @@ const comment = new CommentPlugin<Schemes, AreaExtra>({
 ```
 
 де поле `edit` має приймати асинхронну функцію, яка повертає текст для коментаря.
+
+## Скасування/повторення {#undo-redo}
+
+Зміни коментарів можна додати до стеку скасування/повторення через `rete-history-plugin` і його пресет коментарів. Деталі налаштування — у гайді [Undo/Redo](/uk/docs/guides/undo-redo#comments-preset).
 
 Перегляньте повний результат на сторінці прикладу [Коментарі](/uk/examples/comments).


### PR DESCRIPTION
### Description

Document undo/redo for comments after `rete-history-plugin` / `rete-comment-plugin` 2.2.0 and `rete-kit` 1.21.0.

**Changes (en + uk):**
- `docs/guides/undo-redo` — add **Comments preset** with full setup example (`Presets.comments.setup({ comment })`, `CommentHistoryActions`) and Kit note
- `docs/guides/comments` — short cross-link to undo/redo (no duplicated example); fix `node.dd` → `node.id` in `addInline`

### Related Issues

https://github.com/retejs/history-plugin/pull/42
https://github.com/retejs/comment-plugin/pull/50
https://github.com/retejs/rete-kit/pull/75
https://github.com/retejs/rete-qa/pull/64

### Checklist

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [x] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).


Made with [Cursor](https://cursor.com)